### PR TITLE
Moving from 'loadtest' to 'wrk' for better loadtest performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 
 script:
   - ./tests/latency.sh "http://172.17.0.1:10001" "$(cat openwhisk/ansible/files/auth.guest)"
-  - ./tests/throughput.sh "http://172.17.0.1:10001" "$(cat openwhisk/ansible/files/auth.guest)" 4
+  - ./tests/throughput.sh "http://172.17.0.1:10001" "$(cat openwhisk/ansible/files/auth.guest)" 4 2 2m

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A few simple but efficient performance test suites for Apache OpenWhisk. Determi
 - Limits are set to 999999 each, for the test's load that means: No throttling at all.
 - The deployment uses a docker setup as proposed by the OpenWhisk development team: `overlay` driver and HTTP API enabled via a UNIX port.
 
-The load is driven by the beautiful [`loadtest`](https://www.npmjs.com/package/loadtest) module.
+The load is driven by either the beautiful [`loadtest`](https://www.npmjs.com/package/loadtest) module or the blazingly fast [`wrk`](https://github.com/wg/wrk).
 
 ### Travis' machine setup
 The [machine provided by Travis](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) has ~2 CPU cores (likely shared through virtualization) and 7.5GB memory.

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,6 @@ $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD wipe.yml
 
-$ANSIBLE_CMD consul.yml
 $ANSIBLE_CMD kafka.yml
 $ANSIBLE_CMD controller.yml
 $ANSIBLE_CMD invoker.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,8 +14,7 @@ git clone --depth 1 https://github.com/openwhisk/openwhisk.git
 pip install --user ansible==2.3.0.0
 
 cd openwhisk/ansible
-LIMITS='{"limits":{"actions":{"invokes":{"perMinute":999999,"concurrent":999999,"concurrentInSystem":999999}},"triggers":{"fires":{"perMinute":999999}}}}'
-ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=openwhisk -e docker_registry=docker.io/ -e $LIMITS"
+ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=openwhisk -e docker_registry=docker.io/ -e limit_invocations_per_minute=999999 -e limit_invocations_concurrent=999999 -e limit_invocations_concurrent_system=999999"
 
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml

--- a/tests/latency.sh
+++ b/tests/latency.sh
@@ -13,5 +13,10 @@ action="noopLatency"
 "$currentDir/create.sh" "$host" "$credentials" "$action"
 
 # run latency tests
-encodedAuth=$(echo "$credentials" | base64 -w 0)
-docker run --rm markusthoemmes/loadtest loadtest -n "$samples" -k -m POST -H "Authorization: basic $encodedAuth" "$host/api/v1/namespaces/_/actions/$action?blocking=true"
+encodedAuth=$(echo "$credentials" | base64 | tr -d '\n')
+docker run --rm markusthoemmes/loadtest loadtest \
+  -n "$samples" \
+  -k \
+  -m POST \
+  -H "Authorization: basic $encodedAuth" \
+  "$host/api/v1/namespaces/_/actions/$action?blocking=true"

--- a/tests/post.lua
+++ b/tests/post.lua
@@ -1,0 +1,1 @@
+wrk.method = "POST"

--- a/tests/throughput.sh
+++ b/tests/throughput.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-currentDir="$(dirname "$0")"
+currentDir="$(cd "$(dirname "$0")"; pwd)"
 
 # Host to use. Needs to include the protocol.
 host=$1
@@ -20,11 +20,12 @@ action="noopThroughput"
 
 # run throughput tests
 encodedAuth=$(echo "$credentials" | base64 | tr -d '\n')
-docker run --pid=host --userns=host --rm -v "$(pwd)":/data williamyeh/wrk \
+docker run --pid=host --userns=host --rm -v "$currentDir":/data williamyeh/wrk \
   --threads "$threads" \
   --connections "$concurrency" \
   --duration "$duration" \
   --header "Authorization: basic $encodedAuth" \
   "$host/api/v1/namespaces/_/actions/$action?blocking=true" \
   --latency \
+  --timeout 10s \
   --script post.lua

--- a/tests/throughput.sh
+++ b/tests/throughput.sh
@@ -19,8 +19,8 @@ action="noopThroughput"
 "$currentDir/create.sh" "$host" "$credentials" "$action"
 
 # run throughput tests
-encodedAuth=$(echo "$credentials" | base64 -w0)
-docker run --pid=host --userns=host --rm -v $(pwd):/data williamyeh/wrk \
+encodedAuth=$(echo "$credentials" | base64 | tr -d '\n')
+docker run --pid=host --userns=host --rm -v "$(pwd)":/data williamyeh/wrk \
   --threads "$threads" \
   --connections "$concurrency" \
   --duration "$duration" \


### PR DESCRIPTION
"loadtest" does not closely yield the performance we need to fully saturate at least one controller. "wrk" on the other hand does (/ping on a 16 core machine: 65k rps).

This moves the throughput test to use wrk vs loadtest.

Signed-off-by: Christian Bickel <cbickel@de.ibm.com>